### PR TITLE
Add training helper and video demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,10 +328,11 @@ For instance, for the Occluded-Duke dataset with the SOLIDER pretrained weights:
 Make sure to [download and install the human parsing labels](https://github.com/VlSomers/person-reid/tree/dev-vlad?tab=readme-ov-file#download-annotations-for-existing-datasets) for your training dataset before running this command.
 
 ### Video Re-identification example
-You can run KPR on a custom video by providing a directory containing five reference images:
+You can run KPR on a custom video using the SOTA configuration and automatic
+keypoint annotation. Provide a directory containing five reference images:
 
 ```bash
-python video_reid_demo.py --video my_video.mp4 --ref_dir ref_images --output annotated.mp4
+python video_reid_sota.py --video my_video.mp4 --ref_dir ref_images --output annotated.mp4
 ```
 
 ### Custom training

--- a/README.md
+++ b/README.md
@@ -327,6 +327,21 @@ For instance, for the Occluded-Duke dataset with the SOLIDER pretrained weights:
 
 Make sure to [download and install the human parsing labels](https://github.com/VlSomers/person-reid/tree/dev-vlad?tab=readme-ov-file#download-annotations-for-existing-datasets) for your training dataset before running this command.
 
+### Video Re-identification example
+You can run KPR on a custom video by providing a directory containing five reference images:
+
+```bash
+python video_reid_demo.py --video my_video.mp4 --ref_dir ref_images --output annotated.mp4
+```
+
+### Custom training
+To fine-tune KPR on your own dataset you can use `train_kpr.py` which wraps the official training utilities:
+
+```bash
+python train_kpr.py --config configs/kpr/solider/kpr_occ_duke_train.yaml \
+    --root /path/to/dataset --save_dir log/custom_run
+```
+
 > [!NOTE]
 > This codebase has undergone a big refactoring for the public release. If you cannot replicate some of the reported performance, there is very likely an issue with the training configs, so please open a GitHub issue.
 

--- a/train_kpr.py
+++ b/train_kpr.py
@@ -1,0 +1,46 @@
+import argparse
+import torch
+
+from torchreid.scripts.builder import build_config, build_torchreid_model_engine
+from torchreid.scripts.default_config import engine_run_kwargs
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Train KPR on a custom dataset",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument(
+        "--config",
+        required=True,
+        help="Path to a training config YAML file",
+    )
+    parser.add_argument(
+        "--root",
+        required=True,
+        help="Path to dataset root directory",
+    )
+    parser.add_argument(
+        "--save_dir",
+        default="log/custom_train",
+        help="Directory to store logs and checkpoints",
+    )
+    parser.add_argument(
+        "opts",
+        nargs=argparse.REMAINDER,
+        default=None,
+        help="Override config options using the command line",
+    )
+    args = parser.parse_args()
+
+    cfg = build_config(args=args, config_path=args.config)
+    cfg.use_gpu = torch.cuda.is_available()
+    cfg.data.root = args.root
+    cfg.data.save_dir = args.save_dir
+
+    engine, _ = build_torchreid_model_engine(cfg)
+    engine.run(**engine_run_kwargs(cfg))
+
+
+if __name__ == "__main__":
+    main()

--- a/video_reid_demo.ipynb
+++ b/video_reid_demo.ipynb
@@ -91,6 +91,45 @@
     "# Example usage:\n",
     "# process_video('input.mp4', 'ref_images')"
    ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "video_path = 'my_video.mp4'\n",
+    "ref_dir = 'ref_images'\n",
+    "output_path = 'annotated.mp4'\n"
+   ],
+   "execution_count": null,
+   "outputs": [],
+   "id": "47621586"
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "process_video(video_path, ref_dir, output_path)"
+   ],
+   "execution_count": null,
+   "outputs": [],
+   "id": "906bd32a"
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "cap = cv2.VideoCapture(output_path)\n",
+    "ret, frame = cap.read()\n",
+    "cap.release()\n",
+    "if ret:\n",
+    "    from PIL import Image\n",
+    "    import IPython.display as display\n",
+    "    img = Image.fromarray(cv2.cvtColor(frame, cv2.COLOR_BGR2RGB))\n",
+    "    display.display(img)"
+   ],
+   "execution_count": null,
+   "outputs": [],
+   "id": "20911554"
   }
  ],
  "metadata": {

--- a/video_reid_demo.ipynb
+++ b/video_reid_demo.ipynb
@@ -1,0 +1,109 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "7c02e72b",
+   "metadata": {},
+   "source": [
+    "# Video ReID Demo\n",
+    "This notebook demonstrates how to run the Keypoint Promptable Re-Identification (KPR) model on a video using five reference images."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "276a3ab5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import glob\n",
+    "import os\n",
+    "import cv2\n",
+    "import torch\n",
+    "from torchreid.metrics.distance import compute_distance_matrix_using_bp_features\n",
+    "from torchreid.scripts.builder import build_config\n",
+    "from torchreid.tools.feature_extractor import KPRFeatureExtractor"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a63a9313",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def load_samples(folder):\n",
+    "    image_paths = sorted([p for p in glob.glob(os.path.join(folder, '*')) if p.lower().endswith(('.jpg', '.jpeg', '.png'))])\n",
+    "    if len(image_paths) < 5:\n",
+    "        raise ValueError(f'Need at least 5 reference images in {folder}')\n",
+    "    samples = []\n",
+    "    for path in image_paths[:5]:\n",
+    "        img = cv2.imread(path)\n",
+    "        if img is None:\n",
+    "            raise ValueError(f'Failed to read {path}')\n",
+    "        samples.append({'image': img})\n",
+    "    return samples"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "263bf855",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def process_video(video_path, ref_dir, output_path='output.mp4', config='configs/kpr/imagenet/kpr_occ_posetrack_test.yaml'):\n",
+    "    cfg = build_config(config_path=config)\n",
+    "    cfg.use_gpu = torch.cuda.is_available()\n",
+    "    extractor = KPRFeatureExtractor(cfg)\n",
+    "    ref_samples = load_samples(ref_dir)\n",
+    "    ref_samples, ref_emb, ref_vis, _ = extractor(ref_samples)\n",
+    "    cap = cv2.VideoCapture(video_path)\n",
+    "    if not cap.isOpened():\n",
+    "        raise ValueError(f'Cannot open video {video_path}')\n",
+    "    fourcc = cv2.VideoWriter_fourcc(*'mp4v')\n",
+    "    fps = cap.get(cv2.CAP_PROP_FPS)\n",
+    "    width = int(cap.get(cv2.CAP_PROP_FRAME_WIDTH))\n",
+    "    height = int(cap.get(cv2.CAP_PROP_FRAME_HEIGHT))\n",
+    "    out = cv2.VideoWriter(output_path, fourcc, fps, (width, height))\n",
+    "    while True:\n",
+    "        ret, frame = cap.read()\n",
+    "        if not ret:\n",
+    "            break\n",
+    "        sample = {'image': frame}\n",
+    "        sample, emb, vis, _ = extractor(sample)\n",
+    "        distmat, _ = compute_distance_matrix_using_bp_features(emb, ref_emb, vis, ref_vis, use_gpu=cfg.use_gpu)\n",
+    "        dist = distmat.cpu().numpy()[0] / 2\n",
+    "        best_idx = int(dist.argmin())\n",
+    "        cv2.putText(frame, f'Ref {best_idx}', (10, 30), cv2.FONT_HERSHEY_SIMPLEX, 1, (0, 255, 0), 2)\n",
+    "        out.write(frame)\n",
+    "    out.release()\n",
+    "    cap.release()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7828841f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Example usage:\n",
+    "# process_video('input.mp4', 'ref_images')"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/video_reid_demo.py
+++ b/video_reid_demo.py
@@ -1,0 +1,82 @@
+import argparse
+import glob
+import os
+
+import cv2
+import torch
+
+from torchreid.metrics.distance import compute_distance_matrix_using_bp_features
+from torchreid.scripts.builder import build_config
+from torchreid.tools.feature_extractor import KPRFeatureExtractor
+
+
+def load_samples(folder):
+    image_paths = sorted(
+        p for p in glob.glob(os.path.join(folder, '*'))
+        if p.lower().endswith(('.jpg', '.jpeg', '.png'))
+    )
+    if len(image_paths) < 5:
+        raise ValueError(f'Need at least 5 reference images in {folder}')
+
+    samples = []
+    for path in image_paths[:5]:
+        img = cv2.imread(path)
+        if img is None:
+            raise ValueError(f'Failed to read {path}')
+        samples.append({'image': img})
+    return samples
+
+
+def process_video(video_path, ref_dir, output_path='output.mp4', config='configs/kpr/imagenet/kpr_occ_posetrack_test.yaml'):
+    cfg = build_config(config_path=config)
+    cfg.use_gpu = torch.cuda.is_available()
+    extractor = KPRFeatureExtractor(cfg)
+
+    ref_samples = load_samples(ref_dir)
+    ref_samples, ref_emb, ref_vis, _ = extractor(ref_samples)
+
+    cap = cv2.VideoCapture(video_path)
+    if not cap.isOpened():
+        raise ValueError(f'Cannot open video {video_path}')
+    fourcc = cv2.VideoWriter_fourcc(*'mp4v')
+    fps = cap.get(cv2.CAP_PROP_FPS)
+    width = int(cap.get(cv2.CAP_PROP_FRAME_WIDTH))
+    height = int(cap.get(cv2.CAP_PROP_FRAME_HEIGHT))
+    out = cv2.VideoWriter(output_path, fourcc, fps, (width, height))
+
+    while True:
+        ret, frame = cap.read()
+        if not ret:
+            break
+        sample = {'image': frame}
+        sample, emb, vis, _ = extractor(sample)
+        distmat, _ = compute_distance_matrix_using_bp_features(
+            emb, ref_emb, vis, ref_vis, use_gpu=cfg.use_gpu)
+        dist = distmat.cpu().numpy()[0] / 2
+        best_idx = int(dist.argmin())
+        cv2.putText(frame, f'Ref {best_idx}', (10, 30), cv2.FONT_HERSHEY_SIMPLEX,
+                    1, (0, 255, 0), 2)
+        out.write(frame)
+
+    out.release()
+    cap.release()
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Run KPR model on a video using reference images')
+    parser.add_argument('--video', required=True, help='Input video path')
+    parser.add_argument('--ref_dir', required=True, help='Directory with reference images')
+    parser.add_argument('--output', default='output.mp4', help='Output video path')
+    parser.add_argument(
+        '--config',
+        default='configs/kpr/imagenet/kpr_occ_posetrack_test.yaml',
+        help='Config file for the KPR model')
+    args = parser.parse_args()
+
+    process_video(args.video, args.ref_dir, args.output, args.config)
+
+
+if __name__ == '__main__':
+    main()
+

--- a/video_reid_sota.py
+++ b/video_reid_sota.py
@@ -1,0 +1,107 @@
+import argparse
+import glob
+import os
+
+import cv2
+import numpy as np
+import torch
+
+from torchreid.metrics.distance import compute_distance_matrix_using_bp_features
+from torchreid.scripts.builder import build_config
+from torchreid.tools.feature_extractor import KPRFeatureExtractor
+
+try:
+    import openpifpaf
+except ImportError as e:
+    raise ImportError(
+        "openpifpaf is required for automatic keypoint annotation.\n"
+        "Install it with: pip install openpifpaf"
+    ) from e
+
+
+def detect_keypoints(img, predictor):
+    """Run OpenPifPaf on an RGB image and return keypoints."""
+    predictions, _, _ = predictor.numpy_image(img)
+    if len(predictions) == 0:
+        return np.zeros((17, 3), dtype=float)
+    keypoints = predictions[0].data.reshape(-1, 3)
+    return keypoints
+
+
+def load_reference_samples(folder, predictor):
+    image_paths = sorted(
+        p for p in glob.glob(os.path.join(folder, '*'))
+        if p.lower().endswith(('.jpg', '.jpeg', '.png'))
+    )
+    if len(image_paths) < 5:
+        raise ValueError(f'Need at least 5 reference images in {folder}')
+
+    samples = []
+    for path in image_paths[:5]:
+        img_bgr = cv2.imread(path)
+        if img_bgr is None:
+            raise ValueError(f'Failed to read {path}')
+        img_rgb = cv2.cvtColor(img_bgr, cv2.COLOR_BGR2RGB)
+        kps = detect_keypoints(img_rgb, predictor)
+        samples.append({'image': img_bgr, 'keypoints_xyc': kps, 'negative_kps': np.zeros((0, 17, 3))})
+    return samples
+
+
+def process_video(video_path, ref_dir, output_path='output.mp4',
+                  config='configs/kpr/solider/kpr_occ_duke_test.yaml'):
+    cfg = build_config(config_path=config)
+    cfg.use_gpu = torch.cuda.is_available()
+    extractor = KPRFeatureExtractor(cfg)
+
+    # initialise pifpaf predictor
+    pifpaf_predictor = openpifpaf.Predictor()
+
+    ref_samples = load_reference_samples(ref_dir, pifpaf_predictor)
+    ref_samples, ref_emb, ref_vis, _ = extractor(ref_samples)
+
+    cap = cv2.VideoCapture(video_path)
+    if not cap.isOpened():
+        raise ValueError(f'Cannot open video {video_path}')
+    fourcc = cv2.VideoWriter_fourcc(*'mp4v')
+    fps = cap.get(cv2.CAP_PROP_FPS)
+    width = int(cap.get(cv2.CAP_PROP_FRAME_WIDTH))
+    height = int(cap.get(cv2.CAP_PROP_FRAME_HEIGHT))
+    out = cv2.VideoWriter(output_path, fourcc, fps, (width, height))
+
+    while True:
+        ret, frame_bgr = cap.read()
+        if not ret:
+            break
+        frame_rgb = cv2.cvtColor(frame_bgr, cv2.COLOR_BGR2RGB)
+        kps = detect_keypoints(frame_rgb, pifpaf_predictor)
+        sample = {'image': frame_bgr, 'keypoints_xyc': kps, 'negative_kps': np.zeros((0, 17, 3))}
+        sample, emb, vis, _ = extractor(sample)
+        distmat, _ = compute_distance_matrix_using_bp_features(
+            emb, ref_emb, vis, ref_vis, use_gpu=cfg.use_gpu)
+        dist = distmat.cpu().numpy()[0] / 2
+        best_idx = int(dist.argmin())
+        cv2.putText(frame_bgr, f'Ref {best_idx}', (10, 30), cv2.FONT_HERSHEY_SIMPLEX,
+                    1, (0, 255, 0), 2)
+        out.write(frame_bgr)
+
+    out.release()
+    cap.release()
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Run KPR model on a video with automatic keypoints')
+    parser.add_argument('--video', required=True, help='Input video path')
+    parser.add_argument('--ref_dir', required=True, help='Directory with reference images')
+    parser.add_argument('--output', default='output.mp4', help='Output video path')
+    parser.add_argument(
+        '--config',
+        default='configs/kpr/solider/kpr_occ_duke_test.yaml',
+        help='Config file for the KPR model')
+    args = parser.parse_args()
+
+    process_video(args.video, args.ref_dir, args.output, args.config)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add `train_kpr.py` helper for fine-tuning KPR on custom datasets
- refactor `video_reid_demo.py` into reusable function
- document how to run video demo and custom training in README

## Testing
- `bash linter.sh` *(fails: isort/yapf/flake8 not available)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'scipy')*


------
https://chatgpt.com/codex/tasks/task_e_6840aa27fca883288d333010c6f2a08b